### PR TITLE
recovery: Switch to fluid props

### DIFF
--- a/recovery.cpp
+++ b/recovery.cpp
@@ -816,16 +816,10 @@ Device::BuiltinAction start_recovery(Device* device, const std::vector<std::stri
     ui->SetStage(st_cur, st_max);
   }
 
-  // Extract the YYYYMMDD / YYYYMMDD_HHMMSS timestamp from the full version string.
-  // Assume the first instance of "-[0-9]{8}-", or "-[0-9]{8}_[0-9]{6}-" in case
-  // LINEAGE_VERSION_APPEND_TIME_OF_DAY is set to true has the desired date.
-  std::string ver = android::base::GetProperty("ro.lineage.version", "");
-  std::smatch ver_date_match;
-  std::regex_search(ver, ver_date_match, std::regex("-(\\d{8}(_\\d{6})?)-"));
-  std::string ver_date = ver_date_match.str(1);  // Empty if no match.
+  std::string ver_date = android::base::GetProperty("ro.fluid.build.date", "");
 
   std::vector<std::string> title_lines = {
-    "Version " + android::base::GetProperty("ro.lineage.build.version", "(unknown)") +
+    "Version " + android::base::GetProperty("ro.fluid.build.version", "(unknown)") +
         " (" + ver_date + ")",
   };
   if (android::base::GetBoolProperty("ro.build.ab_update", false)) {


### PR DESCRIPTION
* Fixes unknown version and build date.

* Also stop using regex since fluid has a
  specific prop for build date.

Signed-off-by: DarkJoker360 <simoespo159@gmail.com>